### PR TITLE
Setting version for pyjwt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     },
     install_requires=[
         'httpx[http2]',
-        'PyJWT',
+        'PyJWT==2.0.1',
         'cryptography',
         'pytz',
     ],


### PR DESCRIPTION
Spend a few hours debugging why I was constantly getting InvalidProviderToken error. Eventually narrowed it down to my version of PyJWT, version 1.7.1 had installed. Putting this pull request up to hopefully save other devs some time