### PR TITLE
Accept auth key data directly.

### DIFF
--- a/pyapns_client/client.py
+++ b/pyapns_client/client.py
@@ -20,15 +20,26 @@ class APNSClient:
     AUTH_TOKEN_LIFETIME = 45 * 60  # seconds
     AUTH_TOKEN_ENCRYPTION = 'ES256'
 
-    def __init__(self, mode, root_cert_path, auth_key_path, auth_key_id, team_id):
+    def __init__(self, mode, root_cert_path, auth_key_id, team_id, auth_key_path=None, auth_key=None):
         super().__init__()
 
         if root_cert_path is None:
             root_cert_path = True
+        
+        
+        # Ensure that either the auth key data or the auth key filepath is specified
+        if auth_key_path is None and auth_key is None:
+            raise Exception("Must specify either auth_key_path or auth_key.")
+        
+        # If auth key data specified, use that
+        if auth_key:
+            self._auth_key = auth_key
+        else:
+            # otherwise load from the specified filepath
+            self._auth_key = self._get_auth_key(auth_key_path)        
 
         self._base_url = self.BASE_URLS[mode]
         self._root_cert_path = root_cert_path
-        self._auth_key = self._get_auth_key(auth_key_path)
         self._auth_key_id = auth_key_id
         self._team_id = team_id
 


### PR DESCRIPTION
For use in environment where private key files can’t be on the filesystem.  For 12-factor style deployments (such as Heroku) it is discouraged to put secrets like private keys on the filesystem.  Instead it is recommended to put them into config variables (for Python, accessible via os.environ).

This change makes the APNSClient able to be instantiated with the auth key data specified directly, instead of exclusively via a filepath.  Therefore one could do this:

```python
auth_key = os.environ["APNS_AUTH_KEY"]
client = APNSClient(..., auth_key=auth_key)
```